### PR TITLE
Fix clang 13 compiler warning

### DIFF
--- a/include/mwr/utils/modules.h
+++ b/include/mwr/utils/modules.h
@@ -48,7 +48,7 @@ ostream& operator<<(ostream& os, const module& mod);
 
 class modules
 {
-    friend class module;
+    friend struct module;
 
 private:
     vector<const module*> m_modules;


### PR DESCRIPTION
The friend declaration causes a compiler waring when compiling with clang 13.

warning: 
>class 'module' was previously declared as a struct; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Werror,-Wmismatched-tags]