### PR TITLE
Support relative symlinks

### DIFF
--- a/src/mwr/core/utils.cpp
+++ b/src/mwr/core/utils.cpp
@@ -38,8 +38,11 @@ bool file_exists(const string& file) {
     try {
         size_t limit = 10;
         fs::path path(file);
-        while (fs::is_symlink(path) && limit--)
-            path = fs::read_symlink(path);
+        while (fs::is_symlink(path) && limit--) {
+            fs::path resolved_path = fs::read_symlink(path);
+            path = (resolved_path.is_relative() ? path.parent_path() : "") /
+                   resolved_path;
+        }
         return fs::is_regular_file(path);
     } catch (...) {
         return false;

--- a/test/core/utils.cpp
+++ b/test/core/utils.cpp
@@ -25,15 +25,24 @@
 using namespace mwr;
 
 TEST(utils, paths) {
+    std::filesystem::path pwd = std::filesystem::current_path();
     std::filesystem::create_directory("test");
+    std::filesystem::create_directory("test/dir");
     std::ofstream("test/file");
-    std::filesystem::create_symlink("test", "test/test.link");
-    std::filesystem::create_symlink("test/file", "test/file.link");
-    std::filesystem::create_symlink("test/file.link", "test/file.link.link");
+    std::filesystem::create_symlink(pwd / "test", "test/test.link");
+    std::filesystem::create_symlink(pwd / "test/file", "test/file.link");
+    std::filesystem::create_symlink(pwd / "test/file.link",
+                                    "test/file.link.link");
+    std::filesystem::create_symlink("../file", "test/dir/file.link");
+    std::filesystem::create_symlink("../file.link", "test/dir/file.link.link");
+    std::filesystem::create_symlink("test/file", "test/dir/wrong.link");
 
     EXPECT_TRUE(file_exists("test/file"));
     EXPECT_TRUE(file_exists("test/file.link"));
     EXPECT_TRUE(file_exists("test/file.link.link"));
+    EXPECT_TRUE(file_exists("test/dir/file.link"));
+    EXPECT_TRUE(file_exists("test/dir/file.link.link"));
+    EXPECT_FALSE(file_exists("test/dir/wrong.link"));
 
     EXPECT_TRUE(directory_exists("test"));
     EXPECT_TRUE(directory_exists("test/test.link"));


### PR DESCRIPTION
The `file_exists` function does not work for relative symbolic links. When you create a relative symbolic link using `ln -s -r <source> <dest>`, `<dest>` contains the relative path of `<source>` with respect to the location of `<dest>`. When a relative symbolic link is passed to `file_exists`, the function might return `false` even though the file exists. The problem is that `file_exsists` neglects the parent directory of the symlink. That means, all relative symbolic links are interpreted based on the current working directory of the simulation instead of the parent directory of the relative symlink. This leads to wrong results.