### PR TITLE
windows: fix backslash escape sequences

### DIFF
--- a/include/mwr/stl/strings.h
+++ b/include/mwr/stl/strings.h
@@ -41,7 +41,7 @@ string pad(const string& s, size_t limit);
 string to_lower(const string& s);
 string to_upper(const string& s);
 string escape(const string& s, const string& chars = "");
-string unescape(const string& s);
+string unescape(const string& s, const string& chars = "");
 
 vector<string> split(const string& str, const function<int(int)>& f = isspace);
 vector<string> split(const string& str, char predicate);

--- a/src/mwr/logging/publisher.cpp
+++ b/src/mwr/logging/publisher.cpp
@@ -129,7 +129,7 @@ publisher::~publisher() {
 void publisher::publish(log_level level, const string& sender,
                         const string& str, const char* file, int line) {
     logmsg msg(level, sender);
-    msg.lines = split(str, '\n');
+    msg.lines = split(escape(str), '\n');
 
     if (file != nullptr) {
         msg.source.file = file;

--- a/src/mwr/stl/strings.cpp
+++ b/src/mwr/stl/strings.cpp
@@ -93,7 +93,7 @@ string to_upper(const string& s) {
 string escape(const string& s, const string& chars) {
     stringstream ss;
     for (auto c : s) {
-        for (auto esc : chars + "\\") {
+        for (auto esc : chars + "\\\"'") {
             if (c == esc)
                 ss << '\\';
         }
@@ -103,11 +103,14 @@ string escape(const string& s, const string& chars) {
     return ss.str();
 }
 
-string unescape(const string& s) {
+string unescape(const string& s, const string& chars) {
     stringstream ss;
-    for (auto c : s) {
-        if (c != '\\')
-            ss << c;
+    for (size_t i = 0; i < s.length(); i++) {
+        if (s[i] == '\\' && i < s.length() - 1 &&
+            (chars + "\\\"'").find(s[i + 1]) != string::npos) {
+            ss << s[++i];
+        } else
+            ss << s[i];
     }
 
     return ss.str();

--- a/test/stl/strings.cpp
+++ b/test/stl/strings.cpp
@@ -118,5 +118,5 @@ TEST(strings, strcat) {
 TEST(strings, escape) {
     string s = escape("hello world!", " !");
     ASSERT_EQ(s, "hello\\ world\\!");
-    EXPECT_EQ(unescape(s), "hello world!");
+    EXPECT_EQ(unescape(s, " !"), "hello world!");
 }

--- a/test/stl/strings.cpp
+++ b/test/stl/strings.cpp
@@ -119,4 +119,8 @@ TEST(strings, escape) {
     string s = escape("hello world!", " !");
     ASSERT_EQ(s, "hello\\ world\\!");
     EXPECT_EQ(unescape(s, " !"), "hello world!");
+
+    string s2 = escape("C:\\a\\b\\c");
+    ASSERT_EQ(s2, "C:\\\\a\\\\b\\\\c");
+    EXPECT_EQ(unescape(s2), "C:\\a\\b\\c");
 }


### PR DESCRIPTION
* Properly escape logging strings before passing it to `split` to prevent backslashes from being eaten
* Fix `unscape` so it only unescapes chars that are actually escaped