### PR TITLE
test: avoid UBSAN warning

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,7 +22,7 @@ if(CMAKE_BUILD_TYPE MATCHES "ASAN")
 elseif(CMAKE_BUILD_TYPE MATCHES "TSAN")
     string(APPEND MWR_ENVVAR "TSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/sanitizer/tsan.suppress;")
 elseif(CMAKE_BUILD_TYPE MATCHES "UBSAN")
-    string(APPEND MWR_ENVVAR "UBSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/sanitizer/ubsan.suppress:print_stacktrace=1;")
+    string(APPEND MWR_ENVVAR "UBSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/sanitizer/ubsan.suppress:print_stacktrace=1:halt_on_error=1;")
 endif()
 
 if(APPLE)

--- a/test/core/muldiv.cpp
+++ b/test/core/muldiv.cpp
@@ -56,8 +56,7 @@ TEST(muldiv, imul64) {
         i64 h1, l1;
         imul64_slow(h1, l1, a, b);
 
-        ASSERT_EQ(l0, a * b);
-        ASSERT_EQ(l1, a * b);
+        ASSERT_EQ(l0, l1);
         ASSERT_EQ(h0, h1);
     }
 }


### PR DESCRIPTION
The test compares whether imul64 and imul64_slow produce same result, doing a * b triggered UBSAN warning:
```
signed integer overflow: 7514499718243589878 * 8354455999901540217 
cannot be represented in type 'i64' (aka 'long long')
```