### PR TITLE
socket_win32: check for disconnect

### DIFF
--- a/src/mwr/utils/socket_win32.cpp
+++ b/src/mwr/utils/socket_win32.cpp
@@ -159,7 +159,7 @@ string socket_addr::peer() const {
 }
 
 void socket::disconnect_locked() {
-    if (m_conn != INVALID_SOCKET)
+    if (m_conn == INVALID_SOCKET)
         return;
 
     ::shutdown(m_conn, SD_BOTH);
@@ -258,7 +258,7 @@ void socket::unlisten() {
 
 bool socket::accept() {
     lock_guard<mutex> guard(m_mtx);
-    if (m_conn == INVALID_SOCKET)
+    if (m_conn != INVALID_SOCKET)
         disconnect_locked();
 
     socket_addr addr;
@@ -283,7 +283,7 @@ bool socket::accept() {
 
 void socket::connect(const string& host, u16 port) {
     lock_guard<mutex> guard(m_mtx);
-    if (m_conn == INVALID_SOCKET)
+    if (m_conn != INVALID_SOCKET)
         disconnect_locked();
 
     string pstr = to_string(port);

--- a/src/mwr/utils/terminal.cpp
+++ b/src/mwr/utils/terminal.cpp
@@ -49,6 +49,7 @@ int new_tty() {
 
 bool is_tty(int fd) {
 #ifdef MWR_MSVC
+    std::cout << "Is atty(): " << _isatty(fd) << std::endl;
     return fd >= 0 && _isatty(fd);
 #else
     termios attr;
@@ -122,6 +123,7 @@ public:
 
 #ifdef MWR_MSVC
     bool is_vt100() const {
+        std::cout << "Load: " << load() << std::endl;
         return load() & (ENABLE_VIRTUAL_TERMINAL_INPUT |
                          ENABLE_VIRTUAL_TERMINAL_PROCESSING);
     }

--- a/src/mwr/utils/terminal.cpp
+++ b/src/mwr/utils/terminal.cpp
@@ -49,7 +49,6 @@ int new_tty() {
 
 bool is_tty(int fd) {
 #ifdef MWR_MSVC
-    std::cout << "Is atty(): " << _isatty(fd) << std::endl;
     return fd >= 0 && _isatty(fd);
 #else
     termios attr;
@@ -123,7 +122,6 @@ public:
 
 #ifdef MWR_MSVC
     bool is_vt100() const {
-        std::cout << "Load: " << load() << std::endl;
         return load() & (ENABLE_VIRTUAL_TERMINAL_INPUT |
                          ENABLE_VIRTUAL_TERMINAL_PROCESSING);
     }


### PR DESCRIPTION
These checks were swapped. You only disconnect when the socket is valid.

Noticed when running tests on VSP under Windows.