### PR TITLE
fix: record_type was violating odr

### DIFF
--- a/src/mwr/utils/ihex.cpp
+++ b/src/mwr/utils/ihex.cpp
@@ -12,7 +12,7 @@
 
 namespace mwr {
 
-enum record_type : u8 {
+enum ihex_record_type : u8 {
     IHEX_DATA = 0x00,
     IHEX_EOF = 0x01,
     IHEX_EX_SEG = 0x02,
@@ -27,7 +27,7 @@ enum record_type : u8 {
 };
 
 struct ihex_record {
-    record_type type;
+    ihex_record_type type;
     u64 addr;
     vector<u8> data;
 };
@@ -95,7 +95,7 @@ static inline ihex_record process_line(const string& line) {
     data.reserve(nr_bytes);
     for (size_t pos = data_start; pos < data_start + nr_bytes * 2; pos += 2)
         data.push_back(ihex_byte(line, pos));
-    return { (record_type)r_type, addr, std::move(data) };
+    return { (ihex_record_type)r_type, addr, std::move(data) };
 }
 
 ihex::ihex(const string& filename): m_start_addr(), m_records() {

--- a/src/mwr/utils/srec.cpp
+++ b/src/mwr/utils/srec.cpp
@@ -12,7 +12,7 @@
 
 namespace mwr {
 
-enum record_type : char {
+enum srec_record_type : char {
     SREC_HEADER = '0',
     SREC_DATA16 = '1',
     SREC_DATA24 = '2',


### PR DESCRIPTION
In normal builds, errors don't emerge because the definitions never cross translation units.
With LTO enabled, you get:
```
/mwr/src/mwr/utils/srec.cpp:15: warning: type ‘mwr::record_type’ violates the C++ One Definition Rule [-Wodr]
   15 | enum record_type : char {
      | 
/mwr/src/mwr/utils/ihex.cpp:15: note: an enum with different value name is defined in another translation unit
   15 | enum record_type : u8 {
      | 
/mwr/src/mwr/utils/srec.cpp:16: note: name ‘SREC_HEADER’ differs from name ‘IHEX_DATA’ defined in another translation unit
   16 |     SREC_HEADER = '0',
      | 
/mwr/src/mwr/utils/ihex.cpp:16: note: mismatching definition
   16 |     IHEX_DATA = 0x00,
```