### PR TITLE
feat: adding 128bit division

### DIFF
--- a/include/mwr/core/muldiv.h
+++ b/include/mwr/core/muldiv.h
@@ -94,7 +94,7 @@ constexpr i64 idiv128lo(u64 hi, u64 lo, i64 d) {
     if (hi == 0)
         return (i64)lo / d;
 #ifdef __SIZEOF_INT128__
-    __int128 dividend = ((__int128)hi << 64) | lo;
+    __int128 dividend = ((unsigned __int128)hi << 64) | lo;
     return (i64)(dividend / d);
 #elif defined(MWR_MSVC)
     i64 rem = 0;
@@ -123,7 +123,7 @@ constexpr i64 imod128(u64 hi, u64 lo, i64 d) {
     if (hi == 0)
         return (i64)lo % d;
 #ifdef __SIZEOF_INT128__
-    __int128 dividend = ((__int128)hi << 64) | lo;
+    __int128 dividend = ((unsigned __int128)hi << 64) | lo;
     return (i64)(dividend % d);
 #elif defined(MWR_MSVC)
     i64 rem = 0;

--- a/include/mwr/core/muldiv.h
+++ b/include/mwr/core/muldiv.h
@@ -13,6 +13,7 @@
 
 #include "mwr/core/types.h"
 #include "mwr/core/bitops.h"
+#include "mwr/core/compiler.h"
 
 namespace mwr {
 
@@ -71,6 +72,64 @@ constexpr void imul64(i64& hi, i64& lo, i64 a, i64 b) {
 
 constexpr u64 udivup(u64 a, u64 b) {
     return (a + b - 1) / b;
+}
+
+constexpr u64 udiv128lo(u64 hi, u64 lo, u64 d) {
+    if (d == 0)
+        return 0;
+    if (hi == 0)
+        return lo / d;
+#ifdef __SIZEOF_INT128__
+    unsigned __int128 dividend = ((unsigned __int128)hi << 64) | lo;
+    return (u64)(dividend / d);
+#elif defined(MWR_MSVC)
+    u64 rem;
+    return _udiv128(hi, lo, d, &rem);
+#endif
+}
+
+constexpr i64 idiv128lo(u64 hi, u64 lo, i64 d) {
+    if (d == 0)
+        return 0;
+    if (hi == 0)
+        return (i64)lo / d;
+#ifdef __SIZEOF_INT128__
+    __int128 dividend = ((__int128)hi << 64) | lo;
+    return (i64)(dividend / d);
+#elif defined(MWR_MSVC)
+    i64 rem;
+    return _div128(hi, lo, d, &rem);
+#endif
+}
+
+constexpr u64 umod128(u64 hi, u64 lo, u64 d) {
+    if (d == 0)
+        return 0;
+    if (hi == 0)
+        return lo % d;
+#ifdef __SIZEOF_INT128__
+    unsigned __int128 dividend = ((unsigned __int128)hi << 64) | lo;
+    return (u64)(dividend % d);
+#elif defined(MWR_MSVC)
+    u64 rem;
+    _udiv128(hi, lo, d, &rem);
+    return rem;
+#endif
+}
+
+constexpr i64 imod128(u64 hi, u64 lo, i64 d) {
+    if (d == 0)
+        return 0;
+    if (hi == 0)
+        return (i64)lo % d;
+#ifdef __SIZEOF_INT128__
+    __int128 dividend = ((__int128)hi << 64) | lo;
+    return (i64)(dividend % d);
+#elif defined(MWR_MSVC)
+    i64 rem;
+    _div128(hi, lo, d, &rem);
+    return rem;
+#endif
 }
 
 } // namespace mwr

--- a/include/mwr/core/muldiv.h
+++ b/include/mwr/core/muldiv.h
@@ -83,7 +83,7 @@ constexpr u64 udiv128lo(u64 hi, u64 lo, u64 d) {
     unsigned __int128 dividend = ((unsigned __int128)hi << 64) | lo;
     return (u64)(dividend / d);
 #elif defined(MWR_MSVC)
-    u64 rem;
+    u64 rem = 0;
     return _udiv128(hi, lo, d, &rem);
 #endif
 }
@@ -97,7 +97,7 @@ constexpr i64 idiv128lo(u64 hi, u64 lo, i64 d) {
     __int128 dividend = ((__int128)hi << 64) | lo;
     return (i64)(dividend / d);
 #elif defined(MWR_MSVC)
-    i64 rem;
+    i64 rem = 0;
     return _div128(hi, lo, d, &rem);
 #endif
 }
@@ -111,7 +111,7 @@ constexpr u64 umod128(u64 hi, u64 lo, u64 d) {
     unsigned __int128 dividend = ((unsigned __int128)hi << 64) | lo;
     return (u64)(dividend % d);
 #elif defined(MWR_MSVC)
-    u64 rem;
+    u64 rem = 0;
     _udiv128(hi, lo, d, &rem);
     return rem;
 #endif
@@ -126,7 +126,7 @@ constexpr i64 imod128(u64 hi, u64 lo, i64 d) {
     __int128 dividend = ((__int128)hi << 64) | lo;
     return (i64)(dividend % d);
 #elif defined(MWR_MSVC)
-    i64 rem;
+    i64 rem = 0;
     _div128(hi, lo, d, &rem);
     return rem;
 #endif

--- a/test/core/muldiv.cpp
+++ b/test/core/muldiv.cpp
@@ -110,11 +110,11 @@ TEST(muldiv, idivmod128) {
 
         // we only return the bottom 64bits of the division result, so in
         // order for our test verifcation to work, we clamp hi so that
-        // |hi| < |d|, ensuring the result fits in 64bits without truncation.
-        if (d > 0)
-            hi %= d;
+        // |hi| < |d| / 2, ensuring the result fits in i64 without truncation.
+        if (d > 1)
+            hi %= (d / 2);
         if (d < 0)
-            hi %= -d;
+            hi %= (-d / 2);
 
         i64 div = idiv128lo(hi, lo, d);
         i64 mod = imod128(hi, lo, d);

--- a/test/core/muldiv.cpp
+++ b/test/core/muldiv.cpp
@@ -60,3 +60,76 @@ TEST(muldiv, imul64) {
         ASSERT_EQ(h0, h1);
     }
 }
+
+static void add128(u64& hi, u64& lo, u64 s) {
+    u64 temp = lo;
+    lo += s;
+    if (lo < temp)
+        hi++;
+}
+
+TEST(muldiv, udivmod128) {
+    std::mt19937 rng;
+    std::uniform_int_distribution<u64> dist;
+
+    for (size_t i = 0; i < 1000; i++) {
+        u64 lo = dist(rng);
+        u64 hi = dist(rng);
+        u64 d = dist(rng);
+
+        // we only return the bottom 64bits of the division result, so in
+        // order for our test verifcation to work, we clamp hi to d, so that
+        // the result definitly fits into 64bits without truncation.
+        if (d)
+            hi %= d;
+
+        u64 div = udiv128lo(hi, lo, d);
+        u64 mod = umod128(hi, lo, d);
+
+        if (d == 0) {
+            ASSERT_EQ(div, 0u);
+            ASSERT_EQ(mod, 0u);
+        } else {
+            u64 reslo, reshi;
+            umul64(reshi, reslo, div, d);
+            add128(reshi, reslo, mod);
+            ASSERT_EQ(hi, reshi);
+            ASSERT_EQ(lo, reslo);
+        }
+    }
+}
+
+TEST(muldiv, idivmod128) {
+    std::mt19937 rng;
+    std::uniform_int_distribution<i64> dist;
+
+    for (size_t i = 0; i < 1000; i++) {
+        i64 lo = dist(rng);
+        i64 hi = dist(rng);
+        i64 d = dist(rng);
+
+        // we only return the bottom 64bits of the division result, so in
+        // order for our test verifcation to work, we clamp hi so that
+        // |hi| < |d|, ensuring the result fits in 64bits without truncation.
+        if (d > 0)
+            hi %= d;
+        if (d < 0)
+            hi %= -d;
+
+        i64 div = idiv128lo(hi, lo, d);
+        i64 mod = imod128(hi, lo, d);
+
+        if (d == 0) {
+            ASSERT_EQ(div, 0);
+            ASSERT_EQ(mod, 0);
+        } else {
+            // Use unsigned for the reconstruction to avoid signed overflow
+            // issues The bit patterns are identical in two's complement
+            u64 reslo, reshi;
+            umul64(reshi, reslo, (u64)div, (u64)d);
+            add128(reshi, reslo, mod);
+            ASSERT_EQ((u64)hi, reshi);
+            ASSERT_EQ((u64)lo, reslo);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds helpers to perform 128bit by 64bit division on GCC/Clang and Windows platforms:

* `udiv128lo` returns the low 64bits of an unsigned 128 / 64 bit division
* `odiv128lo` returns the low 64bits of an signed 128 / 64 bit division

I also have added helpers to compute remainders:

* `umod128` returns unsigned 128 % 64 bits
* `imod128` returns signed 128 % 64 bits